### PR TITLE
configure: do not test for CXX, it's not needed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,7 +11,6 @@ AC_CONFIG_HEADER([include/config.h])
 AC_CONFIG_LIBOBJ_DIR(src/common)
 
 # Checks for programs.
-AC_PROG_CXX
 AC_PROG_CC
 AC_PROG_INSTALL
 AC_PROG_LN_S


### PR DESCRIPTION
There is no C++ source file, so no reason to require a C++ compiler.

Reported-by: Peter Korsgaard <jacmet@uclibc.org>
Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/vde2/0001-no-cxx.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>