### PR TITLE
Fix incorrect chacha key size

### DIFF
--- a/src/vde_cryptcab/vde_cryptcab_client.c
+++ b/src/vde_cryptcab/vde_cryptcab_client.c
@@ -109,9 +109,9 @@ rcv_challenge(struct datagram *pkt, struct peer *p)
 			keyname + strlen("/tmp/"),
 			strlen(keyname) - strlen("/tmp/") - strlen(".key"));
 
-	memcpy(ret->key,key,16);
-	memcpy(ret->iv,iv,8);
-	if (write(od,key,16) < 0 || write(od,iv,8) < 0) {
+	memcpy(ret->key,key,CHACHA_MAX_KEY_SZ);
+	memcpy(ret->iv,iv,CHACHA_IV_BYTES);
+	if (write(od,key,CHACHA_MAX_KEY_SZ) < 0 || write(od,iv,CHACHA_IV_BYTES) < 0) {
 		perror("Could not write chacha key");
 		goto failure;
 	}

--- a/src/vde_cryptcab/vde_cryptcab_server.c
+++ b/src/vde_cryptcab/vde_cryptcab_server.c
@@ -258,8 +258,8 @@ rcv_login(struct datagram *pkt, char *pre_shared)
 	sync();
 	usleep(10000);	
 	if (((fd = open (filename, O_RDONLY)) == -1)||
-			((read (fd, pkt->orig->key, 16)) == -1) ||
-			((read (fd, pkt->orig->iv, 8)) == -1) ){
+			((read (fd, pkt->orig->key, CHACHA_MAX_KEY_SZ)) == -1) ||
+			((read (fd, pkt->orig->iv, CHACHA_IV_BYTES)) == -1) ){
 		perror ("chacha.key open error");
 		deny_access(pkt->orig);
 		return;


### PR DESCRIPTION
Aren't these changes needed to complete the work started in 8599321526d0a31925fe55cabbe132b752cb268a for #2?

Unfortunately I'm not familiar with vde2, haven't used it, and don't know how to verify whether these changes are correct.