### PR TITLE
fstp: Add static to inline functions

### DIFF
--- a/src/vde_switch/fstp.c
+++ b/src/vde_switch/fstp.c
@@ -30,14 +30,14 @@ static int numports;
 #ifdef FSTP
 #include <fstp.h>
 /*********************** sending macro used by FSTP & Core ******************/
-void inline ltonstring(unsigned long l,unsigned char *s) {
+static void inline ltonstring(unsigned long l,unsigned char *s) {
 	s[3]=l; l>>=8;
 	s[2]=l; l>>=8;
 	s[1]=l; l>>=8;
 	s[0]=l;
 }
 
-unsigned long inline nstringtol(unsigned char *s) {
+static unsigned long inline nstringtol(unsigned char *s) {
 	return (s[0]<<24)+(s[1]<<16)+(s[2]<<8)+s[3];
 }
 


### PR DESCRIPTION
From [1]
"This is needed to avoid a link error where the inline functions appear
missing at link time.
From c99 standard inline function should either be declared static or
have an extern instance in a c file for linking.
This fix is necessary to build with gcc 7; for some reason it was not
trigerred before."

[1] https://git.buildroot.net/buildroot/commit/?id=21133ada326c87627f7bdee4493d8086587c3cca

Signed-off-by: Romain Naour <romain.naour@gmail.com>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/vde2/0002-fstp-Add-static-to-inline-functions.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>