### PR TITLE
Attempt to fix UNIX_PATH_MAX on non-linux

### DIFF
--- a/src/slirpvde/tcp2unix.h
+++ b/src/slirpvde/tcp2unix.h
@@ -5,8 +5,11 @@
 #ifndef _TCP2UNIX_H
 #define _TCP2UNIX_H
 
+#include <sys/socket.h>
+#include <sys/un.h>
+
 #ifndef UNIX_PATH_MAX
-#define UNIX_PATH_MAX 108
+#define UNIX_PATH_MAX (sizeof(((struct sockaddr_un*)0)->sun_path))
 #endif
 
 extern int tcp2unix_check;


### PR DESCRIPTION
sizeof() on af_unix.sun_path field should fix the buffer overflow in slirpvde, reported in #13 
