### PR TITLE
build: Only use -module for libraries.

### DIFF
--- a/src/vde_l3/Makefile.am
+++ b/src/vde_l3/Makefile.am
@@ -1,7 +1,6 @@
-
 moddir = $(pkglibdir)/vde_l3
 
-AM_LDFLAGS = -module -avoid-version -export-dynamic
+AM_LDFLAGS = -avoid-version -export-dynamic
 AM_LIBTOOLFLAGS = --tag=disable-static
 AM_CPPFLAGS = -I$(top_srcdir)/include
 
@@ -14,6 +13,12 @@ mod_LTLIBRARIES = pfifo.la tbf.la bfifo.la
 pfifo_la_SOURCES = pfifo.c  vde_buff.h
 tbf_la_SOURCES = tbf.c  vde_buff.h
 bfifo_la_SOURCES = bfifo.c  vde_buff.h
+
+vde_l3_lib_LDFLAGS = -module
+
+pfifo_la_LDFLAGS = $(vde_l3_lib_LDFLAGS)
+bfifo_la_LDFLAGS = $(vde_l3_lib_LDFLAGS)
+tbf_la_LDFLAGS = $(vde_l3_lib_LDFLAGS)
 
 pfifo_la_LIBADD = $(top_builddir)/src/common/libvdecommon.la
 bfifo_la_LIBADD = $(top_builddir)/src/common/libvdecommon.la

--- a/src/vde_router/Makefile.am
+++ b/src/vde_router/Makefile.am
@@ -1,7 +1,7 @@
 
 moddir = $(pkglibdir)/vde_router
 
-AM_LDFLAGS = -module -avoid-version -export-dynamic
+AM_LDFLAGS = -avoid-version -export-dynamic
 AM_LIBTOOLFLAGS = --tag=disable-static
 AM_CPPFLAGS = -I$(top_srcdir)/include
 


### PR DESCRIPTION
When building vde with slibtool (https://github.com/midipix-project/slibtool) it will fail.
```
rdlibtool: link: gcc .libs/vde_l3.o -Wl,--whole-archive ../../src/common/.libs/libvdecommon.a -Wl,--no-whole-archive -Wall -O2 -g -O2 -ldl -L../../src/lib/.libs -lvdeplug -ldl -shared -fPIC -Wl,-soname -Wl,vde_l3 -o vde_l3 -Wl,--export-dynamic
gcc: error: .libs/vde_l3.o: No such file or directory
rdlibtool: exec error upon slbt_exec_link_create_library(), line 1446: (see child process error messages).
rdlibtool: < returned to > slbt_exec_link(), line 1826.
make[2]: *** [Makefile:492: vde_l3] Error 2
```
This is because these binaries are being built with`-module` which will not work, GNU libtool works because it silently filters out `-module` while slibtool does not.

This PR will remove `-module` so that it is only used for actual libraries.

From the slibtool `--help`:
```
-module                    create a shared object that will only be loaded
                           at runtime via dlopen(3). the shared object name
                           need not follow the platform's library naming
                           conventions
```
Also see this downstream issue: https://bugs.gentoo.org/775272