### PR TITLE
configure: Check for wolfSSL instead of OpenSSL.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@ AC_DEFINE_UNQUOTED(MODULES_EXT, "$shrext_cmds", [Extension of shared objects])
 
 # Checks for libraries.
 AC_CHECK_LIB([dl], [dlopen])
-AC_CHECK_LIB([crypto], [EVP_EncryptInit],
+AC_CHECK_LIB([wolfssl], [wc_Chacha_Process],
   [add_cryptcab_support=yes],
   [add_cryptcab_support=no ; warn_cryptcab=yes])
 AC_CHECK_LIB([pthread], [pthread_create],


### PR DESCRIPTION
When building VDE in a pure environment containing only its dependencies (this is done e.g. by GNU Guix) the configure script seemingly fails to detect wolfSSL:
``` text
Configure results:

 - VDE CryptCab............ disabled
 + VDE Router.............. enabled
 + VDE VXLAN............... enabled
 + Python Libraries........ enabled
 + TAP support............. enabled
 + pcap support............ enabled
 - Experimental features... disabled
 - Profiling options....... disabled
 - Kernel switch........... disabled


configure: WARNING: VDE CryptCab support has been disabled because wolfSSL is
not installed on your system, or because wolfssl/wolfcrypt/chacha.h could not be found.
Please install libwolfssl if you want CryptCab to be compiled and installed.
```
This happens because the configure script doesn't actually check for the presence of libwolfssl (provided by wolfSSL), as the warning would suggest.  Instead it checks whether a former dependency, libcrypto (provided by OpenSSL) is available:
```autoconf
AC_CHECK_LIB([crypto], [EVP_EncryptInit],
  [add_cryptcab_support=yes],
  [add_cryptcab_support=no ; warn_cryptcab=yes])
```
This pull request adjusts the check, so that it looks for VDE CryptCab's current dependency.