### PR TITLE
configure.ac: Downgrade autoconf from 2.71 to 2.59 ; Add CI (GitHub Actions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: "CI"
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  smoke:
+    name: "Smoke test"
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, macos-11]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    steps:
+      - name: "Check out"
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: "Install dependencies (Linux)"
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y autoconf automake
+      - name: "Install dependencies (macOS)"
+        if: runner.os == 'macOS'
+        run: brew install autoconf automake
+      - name: "Build"
+        run: |
+          autoreconf -fis
+          ./configure --prefix=/opt/vde
+          make
+          sudo make install
+      - name: "Smoke test"
+        run: |
+          /opt/vde/bin/vde_switch --version

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 #                                               -*- Autoconf -*-/
 # Process this file with autoconf to produce a configure script.
 
-AC_PREREQ([2.71])
+AC_PREREQ([2.59])
 AC_INIT([vde2],[2.3.2],[info@v2.cs.unibo.it])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign dist-bzip2 subdir-objects])
@@ -32,7 +32,6 @@ AC_CHECK_LIB([pcap], [pcap_open_dead],
   [add_pcap=no ; warn_pcap=yes])
 
 # Checks for header files.
-AC_CHECK_INCLUDES_DEFAULT
 AC_PROG_EGREP
 
 AC_HEADER_SYS_WAIT


### PR DESCRIPTION
Autoconf 2.71 is not available for most distros yet: https://pkgs.org/search/?q=autoconf

|Distro                |autoconf|
|----------------------|--------|
|AlmaLinux 8 and Rocky Linux 8          |2.69    |
|Debian GNU/Linux 11   |2.69    |
|Fedora 35             |2.69    |
|openSUSE Leap 15.3         |2.69    |
|Ubuntu 21.10          |2.69    |
|Arch Linux            |2.71    |
|Alpine Linux 3.15           |2.71    |

    
Removal of `AC_CHECK_INCLUDES_DEFAULT` (introduced in 2.70) is safe,  according to https://www.gnu.org/software/autoconf/manual/autoconf-2.70/html_node/Default-Includes.html
    
Partially revert commit 4f42a4ba68e53a88e9ffe914ba0c420873d8860b (PR #32)

This PR also adds CI (GitHub Actions).


- - -

CI result (✅  Passing) https://github.com/AkihiroSuda/vde-2/actions/runs/1586766772