### PR TITLE
Makefile.am: drop COPYING.slirpvde

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 SUBDIRS = include src man doc
 ACLOCAL_AMFLAGS = -I m4
 
-EXTRA_DIST = Changelog COPYING COPYING.libvdeplug COPYING.slirpvde INSTALL README
+EXTRA_DIST = Changelog COPYING COPYING.libvdeplug INSTALL README
 
 DISTCHECK_CONFIGURE_FLAGS = --enable-experimental
 


### PR DESCRIPTION
`COPYING.slirpvde` was dropped by https://github.com/virtualsquare/vde-2/commit/14e1c9e06f4dbdddc6fe4e85fc72a1d583b049ad