### PR TITLE
fix: socklen_t initialization

### DIFF
--- a/src/vde_autolink.c
+++ b/src/vde_autolink.c
@@ -1156,9 +1156,7 @@ static int newmgmtconn(int fd,struct pollfd *pfd,int nfds)
 {
 	int new;
 	char buf[MAXCMD];
-	struct sockaddr addr;
-	socklen_t len = sizeof(addr);
-	new = accept(fd, &addr, &len);
+	new = accept(fd, NULL, NULL);
 	if(new < 0){
 		printlog(LOG_ERR,"mgmt accept %s",strerror(errno));
 		return nfds;

--- a/src/vde_autolink.c
+++ b/src/vde_autolink.c
@@ -1155,9 +1155,9 @@ static int mgmtcommand(int fd)
 static int newmgmtconn(int fd,struct pollfd *pfd,int nfds)
 {
 	int new;
-	unsigned int len;
 	char buf[MAXCMD];
 	struct sockaddr addr;
+	socklen_t len = sizeof(addr);
 	new = accept(fd, &addr, &len);
 	if(new < 0){
 		printlog(LOG_ERR,"mgmt accept %s",strerror(errno));

--- a/src/vde_router/vde_router.c
+++ b/src/vde_router/vde_router.c
@@ -1350,9 +1350,7 @@ static int newmgmtconn(int fd,struct pollfd *pfd,int nfds)
 {
 	int new;
 	char buf[MAXCMD];
-	struct sockaddr addr;
-	socklen_t len = sizeof(addr);
-	new = accept(fd, &addr, &len);
+	new = accept(fd, NULL, NULL);
 	if(new < 0) {
 		fprintf(stderr, "mgmt accept %s",strerror(errno));
 		return nfds;

--- a/src/vde_router/vde_router.c
+++ b/src/vde_router/vde_router.c
@@ -1349,9 +1349,9 @@ int config_readline (int fd, char *l)
 static int newmgmtconn(int fd,struct pollfd *pfd,int nfds)
 {
 	int new;
-	unsigned int len;
 	char buf[MAXCMD];
 	struct sockaddr addr;
+	socklen_t len = sizeof(addr);
 	new = accept(fd, &addr, &len);
 	if(new < 0) {
 		fprintf(stderr, "mgmt accept %s",strerror(errno));

--- a/src/wirefilter.c
+++ b/src/wirefilter.c
@@ -944,9 +944,7 @@ static int newmgmtconn(int fd,struct pollfd *pfd,int nfds)
 {
 	int new;
 	char buf[MAXCMD];
-	struct sockaddr addr;
-  	socklen_t len = sizeof(addr);
-	new = accept(fd, &addr, &len);
+	new = accept(fd, NULL, NULL);
 	if(new < 0){
 		printlog(LOG_WARNING,"mgmt accept %s",strerror(errno));
 		return nfds;

--- a/src/wirefilter.c
+++ b/src/wirefilter.c
@@ -943,9 +943,9 @@ static char prompt[]="\nVDEwf$ ";
 static int newmgmtconn(int fd,struct pollfd *pfd,int nfds)
 {
 	int new;
-	unsigned int len;
 	char buf[MAXCMD];
 	struct sockaddr addr;
+  	socklen_t len = sizeof(addr);
 	new = accept(fd, &addr, &len);
 	if(new < 0){
 		printlog(LOG_WARNING,"mgmt accept %s",strerror(errno));


### PR DESCRIPTION
I've noticed that sometimes, when you try to connect to a wirefilter cable with vdeterm, the connection hangs. The bug was that on wirefilter the `len` parameter on `accept` was not initialized. As the man page says:
> The  addrlen  argument is a value-result argument: the caller must initialize it to contain the size (in bytes) of the structure pointed to by addr; on return it will contain the actual size of the peer address.

This fix the wirefilter bug. I've also found that this bug was present on `vde_router` and `vde_autolink`, so i fix those too.