### PR TITLE
Fix: CMake variables and segfault on vdecmd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(vde2
 include(GNUInstallDirs)
 include(./Macros.cmake)
 
-add_definitions(-DSYSCONFDIR=\"${CMAKE_INSTALL_SYSCONFDIR}\" -DLOCALSTATEDIR=\"${CMAKE_INSTALL_LOCALSTATEDIR}\")
+add_definitions(-DSYSCONFDIR=\"/${CMAKE_INSTALL_SYSCONFDIR}\" -DLOCALSTATEDIR=\"/${CMAKE_INSTALL_LOCALSTATEDIR}\")
 
 cm_define_project(
     ${PROJECT_VERSION} 

--- a/src/unixcmd.c
+++ b/src/unixcmd.c
@@ -56,6 +56,7 @@ int main(int argc,char *argv[])
 		{"rcfile", 1, 0, 'f'},
 		{"sock", 1, 0, 's'},
 		{"verbose", 0, 0, 'v'},
+    		{ 0, 0, 0, 0},
 	};
 	int c;
 	while ((c=getopt_long (argc, argv, "f:s:v",


### PR DESCRIPTION
After the CMake porting (674c8ec) the `vdecmd` was broken. The problem was that for CMake the variables`CMAKE_INSTALL_SYSCONFDIR` and `CMAKE_INSTALL_LOCALSTATEDIR` do not start with a `/`: https://cmake.org/cmake/help/latest/command/install.html.

I added the `/`.

I have also added the empty element at the end of the array of the options for getopt in order to avoid segfaults on invalid arguments. From the docs of getopt:
>        The last element of the array has to be filled with zeros.
